### PR TITLE
Fix cancel

### DIFF
--- a/DelfinCore/Cryptor.cs
+++ b/DelfinCore/Cryptor.cs
@@ -176,7 +176,11 @@ namespace DelfinForWindows
             }
 
             if (QuitIfCancellationRequested()) return;
-            io.FileSaver.Handle(fileBuffer);
+            if (!io.FileSaver.Handle(fileBuffer))
+            {
+                HandleError("Error saving file", "The file could not be saved.");
+                return;
+            }
             ProcessResult(new() { Success = true });
         }
 
@@ -317,12 +321,15 @@ namespace DelfinForWindows
                 {
                     pairBuffer[i] = pairBuffer[i + 3];
                 }
-
                 population -= 3;
             }
 
             if (QuitIfCancellationRequested()) return;
-            io.ImageSaver.Handle(img);
+            if (!io.ImageSaver.Handle(img))
+            {
+                HandleError("Error saving file", "The file could not be saved.");
+                return;
+            }
             ProcessResult(new() { Success = true });
         }
     }

--- a/DelfinCore/Cryptor.cs
+++ b/DelfinCore/Cryptor.cs
@@ -321,6 +321,7 @@ namespace DelfinForWindows
                 {
                     pairBuffer[i] = pairBuffer[i + 3];
                 }
+
                 population -= 3;
             }
 

--- a/DelfinCore/Cryptor.cs
+++ b/DelfinCore/Cryptor.cs
@@ -43,7 +43,7 @@ namespace DelfinForWindows
 
     public class Cryptor
     {
-        public static void Decrypt(string imgName, string password, string saveFilename, CancellationToken token, Action<CryptionResult> ProcessResult)
+        public static void Decrypt(string imgName, string password, string saveFilename, Action<CryptionResult> ProcessResult, CancellationToken token)
         {
             void HandleError(string err, string errDesc)
             {
@@ -54,10 +54,10 @@ namespace DelfinForWindows
             var fileSaver = new FileSystemByteArrayHandler(".zip", HandleError) { Filename = saveFilename };
             var decryptorIO = new DecryptorIO(imageLoader, fileSaver);
 
-            Decrypt(decryptorIO, password, token, ProcessResult);
+            Decrypt(decryptorIO, password, ProcessResult, token);
         }
 
-        public static void Decrypt(DecryptorIO io, string password, CancellationToken token, Action<CryptionResult> ProcessResult)
+        public static void Decrypt(DecryptorIO io, string password, Action<CryptionResult> ProcessResult, CancellationToken token)
         {
             void HandleError(string err, string errDesc)
             {
@@ -184,7 +184,7 @@ namespace DelfinForWindows
             ProcessResult(new() { Success = true });
         }
 
-        public static void Encrypt(string imgName, string filename, string password, string saveFilename, CancellationToken token, Action<CryptionResult> ProcessResult)
+        public static void Encrypt(string imgName, string filename, string password, string saveFilename, Action<CryptionResult> ProcessResult, CancellationToken token)
         {
             void HandleError(string err, string errDesc)
             {
@@ -196,10 +196,10 @@ namespace DelfinForWindows
             var imageSaver = new FileSystemBitmapHandler(HandleError) { Filename = saveFilename };
             var encryptorIO = new EncryptorIO(imageLoader, fileLoader, imageSaver);
 
-            Encrypt(encryptorIO, password, token, ProcessResult);
+            Encrypt(encryptorIO, password, ProcessResult, token);
         }
 
-        public static void Encrypt(EncryptorIO io, string password, CancellationToken token, Action<CryptionResult> ProcessResult)
+        public static void Encrypt(EncryptorIO io, string password, Action<CryptionResult> ProcessResult, CancellationToken token)
         {
             void HandleError(string err, string errDesc)
             {

--- a/DelfinForWindows/Form_main.cs
+++ b/DelfinForWindows/Form_main.cs
@@ -531,7 +531,7 @@ namespace DelfinForWindows
                 return;
             }
 
-            Cryptor.Decrypt(imgName, password, saveFilename, token, (result) => ProcessResult(result, MODE.DECRYPT));
+            Cryptor.Decrypt(imgName, password, saveFilename, (result) => ProcessResult(result, MODE.DECRYPT), token);
         }
 
         private void Encrypt(string imgName, string filename, string password, CancellationToken token)
@@ -549,7 +549,7 @@ namespace DelfinForWindows
                 return;
             }
 
-            Cryptor.Encrypt(imgName, filename, password, saveFilename, token, (result) => ProcessResult(result, MODE.ENCRYPT));
+            Cryptor.Encrypt(imgName, filename, password, saveFilename, (result) => ProcessResult(result, MODE.ENCRYPT), token);
         }
 
         private void ProcessResult(bool success, string errMsg, string errDescription, MODE mode)

--- a/DelfinForWindows/Form_main.cs
+++ b/DelfinForWindows/Form_main.cs
@@ -520,9 +520,16 @@ namespace DelfinForWindows
         {
             UpdateFeed($"Decrypting {openFileDialog_image.FileName.ShortFileName()}...");
 
-            string saveFilename = saveFileDialog_zip.ShowDialog() == DialogResult.OK
-                ? saveFileDialog_zip.FileName
-                : "";
+            string saveFilename;
+            if (saveFileDialog_zip.ShowDialog() == DialogResult.OK)
+            {
+                saveFilename = saveFileDialog_zip.FileName;
+            }
+            else
+            {
+                ProcessResult(false, "Cancelled operation", "Saving the result was cancelled.", MODE.DECRYPT);
+                return;
+            }
 
             Cryptor.Decrypt(imgName, password, saveFilename, token, (result) => ProcessResult(result, MODE.DECRYPT));
         }
@@ -531,9 +538,16 @@ namespace DelfinForWindows
         {
             UpdateFeed($"Encrypting {openFileDialog_zip.FileName.ShortFileName()} into {openFileDialog_image.FileName.ShortFileName()}...");
 
-            string saveFilename = saveFileDialog_image.ShowDialog() == DialogResult.OK
-                ? saveFileDialog_image.FileName
-                : "";
+            string saveFilename;
+            if (saveFileDialog_image.ShowDialog() == DialogResult.OK)
+            {
+                saveFilename = saveFileDialog_image.FileName;
+            }
+            else
+            {
+                ProcessResult(false, "Cancelled operation", "Saving the result was cancelled.", MODE.ENCRYPT);
+                return;
+            }
 
             Cryptor.Encrypt(imgName, filename, password, saveFilename, token, (result) => ProcessResult(result, MODE.ENCRYPT));
         }

--- a/DelfinForWindows/Form_main.cs
+++ b/DelfinForWindows/Form_main.cs
@@ -538,22 +538,24 @@ namespace DelfinForWindows
             Cryptor.Encrypt(imgName, filename, password, saveFilename, token, (result) => ProcessResult(result, MODE.ENCRYPT));
         }
 
-        private void ProcessResult(CryptionResult result, MODE mode)
+        private void ProcessResult(bool success, string errMsg, string errDescription, MODE mode)
         {
             string modeString = mode == MODE.DECRYPT ? "Decryption" : "Encryption";
-            if (result.Success)
+            if (success)
             {
                 UpdateFeed($"{modeString} successful.");
                 ShowMessage($"{modeString} successful.", "Success");
             }
             else
             {
-                UpdateFeed($"{modeString} failed. Reason: {result.ErrDescription}");
-                ShowMessage($"{modeString} failed. Reason: {result.ErrDescription}", $"{result.ErrMsg}");
+                UpdateFeed($"{modeString} failed. Reason: {errDescription}");
+                ShowMessage($"{modeString} failed. Reason: {errDescription}", $"{errMsg}");
             }
 
             InitializeStateAndButtons();
         }
+
+        private void ProcessResult(CryptionResult result, MODE mode) => ProcessResult(result.Success, result.ErrMsg, result.ErrDescription, mode);
 
         // threadsafe call to enter primary state, enabling/disabling certain buttons and setting flags
         private void InitializeStateAndButtons()

--- a/DelfinForWindows/Form_main.cs
+++ b/DelfinForWindows/Form_main.cs
@@ -590,6 +590,8 @@ namespace DelfinForWindows
             button_cancel.Enabled = false;
             SetInfoText(mainWelcomeInfo);
             cryptionThread = null;
+            cancellationTokenSource?.Dispose();
+            cancellationTokenSource = null;
         }
     }
 

--- a/DelfinForWindows/Form_main.cs
+++ b/DelfinForWindows/Form_main.cs
@@ -443,8 +443,6 @@ namespace DelfinForWindows
         private void Button_cancel_Click(object sender, EventArgs e)
         {
             cancellationTokenSource?.Cancel();
-            cancellationTokenSource?.Dispose();
-            cancellationTokenSource = null;
 
             InitializeStateAndButtons();
         }

--- a/DelfinForWindows/Form_main.cs
+++ b/DelfinForWindows/Form_main.cs
@@ -427,13 +427,13 @@ namespace DelfinForWindows
             {
                 midgroundProcess = new Thread(EncryptWrapper);
                 midgroundProcess.SetApartmentState(ApartmentState.STA);
-                midgroundProcess.Start(new Tuple<string, string, string>(openFileDialog_image.FileName, openFileDialog_zip.FileName, textBox_password.Text));
+                midgroundProcess.Start((openFileDialog_image.FileName, openFileDialog_zip.FileName, textBox_password.Text));
             }
             else if (mode == MODE.DECRYPT)
             {
                 midgroundProcess = new Thread(DecryptWrapper);
                 midgroundProcess.SetApartmentState(ApartmentState.STA);
-                midgroundProcess.Start(new Tuple<string, string>(openFileDialog_image.FileName, textBox_password.Text));
+                midgroundProcess.Start((openFileDialog_image.FileName, textBox_password.Text));
             }
         }
 
@@ -527,12 +527,9 @@ namespace DelfinForWindows
             MessageBox.Show(text, caption);
         }
 
-        // string imgName, string password
         private void Decrypt(object args)
         {
-            var input = (Tuple<string, string>)args;
-            string imgName = input.Item1;
-            string password = input.Item2;
+            var (imgName, password) = ((string, string))args;
 
             string saveFilename = saveFileDialog_zip.ShowDialog() == DialogResult.OK
                 ? saveFileDialog_zip.FileName
@@ -541,13 +538,9 @@ namespace DelfinForWindows
             Cryptor.Decrypt(imgName, password, saveFilename, (result) => ProcessResult(result, MODE.DECRYPT));
         }
 
-        // string imgName, string fileName, string password
         private void Encrypt(object args)
         {
-            var input = (Tuple<string, string, string>)args;
-            string imgName = input.Item1;
-            string fileName = input.Item2;
-            string password = input.Item3;
+            var (imgName, fileName, password) = ((string, string, string))args;
 
             string saveFilename = saveFileDialog_image.ShowDialog() == DialogResult.OK
                 ? saveFileDialog_image.FileName

--- a/IOHandler/IOHandlers.cs
+++ b/IOHandler/IOHandlers.cs
@@ -137,12 +137,12 @@ namespace IOHandler
             HandleError = errorHandler ?? IWithErrorHandler.DefaultErrorHandler;
         }
 
-        public void Handle(Bitmap item)
+        public bool Handle(Bitmap item)
         {
             if (!Filename.EndsWith(".png"))
             {
                 HandleError("Wrong file type", $"Expected {Filename} to be a .png file.");
-                return;
+                return false;
             }
 
             FileStream writer;
@@ -159,21 +159,22 @@ namespace IOHandler
             {
                 // path is null, empty, or invalid due to length, drive, or characters
                 HandleError("invalid path name", $"The path\r\n{Filename}\r\nis not a valid path. Please specify a valid path.");
-                return;
+                return false;
             }
             catch (IOException)
             {
                 HandleError("unexpected I/O error", "An I/O error occurred while using the file.");
-                return;
+                return false;
             }
             catch (System.Security.SecurityException)
             {
                 HandleError("unauthorized access", $"You don't have permission to access the file:\r\n{Filename}");
-                return;
+                return false;
             }
 
             item.Save(writer, System.Drawing.Imaging.ImageFormat.Png);
             writer.Dispose();
+            return true;
         }
     }
 
@@ -191,12 +192,12 @@ namespace IOHandler
             FileExtension = fileExtension;
         }
 
-        public void Handle(byte[] item)
+        public bool Handle(byte[] item)
         {
             if (!Filename.EndsWith(FileExtension))
             {
                 HandleError("Wrong file type", $"Expected {Filename} to end with {FileExtension}");
-                return;
+                return false;
             }
 
             BinaryWriter writer;
@@ -214,20 +215,21 @@ namespace IOHandler
             {
                 // path is null, empty, or invalid due to length, drive, or characters
                 HandleError("invalid path name", $"The path\r\n{Filename}\r\nis not a valid path. Please specify a valid path.");
-                return;
+                return false;
             }
             catch (IOException)
             {
                 HandleError("unexpected I/O error", "An I/O error occurred while using the file.");
-                return;
+                return false;
             }
             catch (UnauthorizedAccessException)
             {
                 HandleError($"You don't have permission to access the file:\r\n{Filename}", "unauthorized access");
-                return;
+                return false;
             }
 
             writer.Dispose();
+            return true;
         }
     }
 }

--- a/IOHandler/IWithErrorHandler.cs
+++ b/IOHandler/IWithErrorHandler.cs
@@ -21,6 +21,6 @@ namespace IOHandler
 
     public interface IHandler<T> : IWithErrorHandler
     {
-        public void Handle(T item);
+        public bool Handle(T item);
     }
 }


### PR DESCRIPTION
The original method of cancellation supported by Delfin was using `Thread.Abort()`, which was deprecated by the move to .NET 5.0. This PR implements [cooperative cancellation](https://docs.microsoft.com/en-us/dotnet/standard/threading/cancellation-in-managed-threads), allowing for a more managable and modern form of cancellation. This also allowed for much homebrew scaffolding to be removed, and also makes cancellation native to `DelfinCore`, instead of an afterthought.